### PR TITLE
[Feat] #6 개인정보 타입 및 모델 경로 설정

### DIFF
--- a/app/models/personal_info.py
+++ b/app/models/personal_info.py
@@ -1,30 +1,28 @@
 """
-개인정보 타입 상수
+개인정보 타입 및 모델 경로 설정
 """
-from enum import Enum
+PII_CATEGORIES = ["p_nm", "p_rrn", "p_add", "p_ip", "p_ph", "p_acn", "p_pp", "p_em"]
 
-
-class PersonalInfoType(str, Enum):
-    """개인정보 8종류"""
-    NAME = "name"  # 이름
-    RRN = "rrn"  # 주민번호
-    ADDRESS = "address"  # 집주소
-    IP_ADDRESS = "ip_address"  # IP주소
-    PHONE = "phone"  # 전화번호
-    ACCOUNT = "account"  # 계좌번호
-    PASSPORT = "passport"  # 여권번호
-    EMAIL = "email"  # 이메일
-
-
-# 개인정보 종류별 가중치
-PERSONAL_INFO_WEIGHTS = {
-    PersonalInfoType.RRN: 10,
-    PersonalInfoType.PASSPORT: 9,
-    PersonalInfoType.ACCOUNT: 8,
-    PersonalInfoType.NAME: 5,
-    PersonalInfoType.ADDRESS: 5,
-    PersonalInfoType.PHONE: 4,
-    PersonalInfoType.EMAIL: 3,
-    PersonalInfoType.IP_ADDRESS: 2,
+PII_NAMES = {
+    "p_nm": "이름",
+    "p_rrn": "주민번호",
+    "p_add": "주소",
+    "p_ip": "IP주소",
+    "p_ph": "전화번호",
+    "p_acn": "계좌번호",
+    "p_pp": "여권번호",
+    "p_em": "이메일"
 }
 
+CONFIDENCE_THRESHOLDS = {
+    "p_nm": 0.70,    # 이름
+    "p_rrn": 0.95,   # 주민번호
+    "p_add": 0.70,   # 주소
+    "p_ip": 0.80,    # IP주소
+    "p_ph": 0.70,    # 전화번호
+    "p_acn": 0.90,   # 계좌번호
+    "p_pp": 0.75,    # 여권번호
+    "p_em": 0.70     # 이메일
+}
+
+DEFAULT_MODEL_PATH = "ParkJunSeong/PIILOT_NER_Model"


### PR DESCRIPTION
## 개요
- closed #6

개인정보 타입 관리 방식을 Enum 기반에서 NER 모델에서 사용하는 PII 코드 기반 상수 구조로 변경했습니다.
엔티티별 신뢰도 임계값과 기본 HuggingFace 모델 경로를 함께 정의하여 추후 모델 교체 및 정책 변경을 쉽게 하기 위함입니다.

Resolves: #6

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
- PersonalInfoType(Enum) 제거 후 문자열 기반 PII 코드로 통합했습니다.
- PERSONAL_INFO_WEIGHTS → CONFIDENCE_THRESHOLDS로 변경되었습니다.
- 기본 Hugging Face NER 모델 경로를 상수로 관리합니다.
